### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,12 @@ on:
       - "uuidv7/**"
       - "benchmarks/**"
       - ".github/workflows/benchmark.yml"
+  pull_request:
+    branches: [main, master]
+    paths:
+      - "uuidv7/**"
+      - "benchmarks/**"
+      - ".github/workflows/benchmark.yml"
   workflow_dispatch:
 
 jobs:
@@ -20,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -36,7 +42,14 @@ jobs:
       - name: Run benchmarks
         run: |
           source .venv/bin/activate
-          python benchmarks/benchmark.py
+          python benchmarks/benchmark.py --output benchmark-results.md
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-results.md
+          retention-days: 14
 
       - name: Comment benchmark results
         if: github.event_name == 'pull_request'
@@ -59,3 +72,32 @@ jobs:
               body: output
             });
 
+  clock-sources:
+    name: Clock Sources on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Run clock source benchmark
+        run: python benchmarks/clock_sources.py --output clock-source-results.md
+
+      - name: Upload clock source results
+        uses: actions/upload-artifact@v4
+        with:
+          name: clock-source-results-${{ matrix.os }}
+          path: clock-source-results.md
+          retention-days: 14

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,11 @@ on:
       - ".github/workflows/benchmark.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   benchmark:
     name: Run Benchmarks
@@ -53,19 +58,14 @@ jobs:
 
       - name: Comment benchmark results
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `## Benchmark Results
-            
-            Benchmarks completed successfully. See [BENCHMARK_RESULTS.md](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/BENCHMARK_RESULTS.md) for detailed results.
-            
-            Run benchmarks locally:
-            \`\`\`bash
-            python benchmarks/benchmark.py
-            \`\`\`
-            `;
-            github.rest.issues.createComment({
+            const fs = require("fs");
+            const results = fs.readFileSync("benchmark-results.md", "utf8");
+            const output = `## Benchmark Results\n\n${results}`;
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -94,4 +94,3 @@ jobs:
           name: dist
           path: dist/*
           retention-days: 7
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "pp* *-musllinux_*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,13 +11,9 @@ on:
         type: string
 
 jobs:
-  publish:
-    name: Publish to PyPI
+  sdist:
+    name: Build sdist
     runs-on: ubuntu-latest
-    environment: pypi  # Optional: use GitHub environment for additional security
-    permissions:
-      contents: read
-      id-token: write  # Required for trusted publishing
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -34,11 +30,60 @@ jobs:
 
       - name: Build package
         run: |
-          uv build
+          uv build --sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          retention-days: 7
+
+  wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2
+        env:
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_SKIP: "pp* *-musllinux_*"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_TEST_COMMAND: >-
+            python -c "import uuid, uuidv7; u = uuidv7.uuid7(); assert isinstance(u, uuid.UUID); assert u.version == 7; assert str(u).count('-') == 4"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [sdist, wheels]
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
           print-hash: true
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15-intel, windows-latest]
+        include:
+          - os: ubuntu-latest
+            cibw-archs-macos: auto
+          - os: macos-15-intel
+            cibw-archs-macos: x86_64
+          - os: macos-15
+            cibw-archs-macos: arm64
+          - os: windows-latest
+            cibw-archs-macos: auto
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +63,7 @@ jobs:
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw-archs-macos }}
           CIBW_TEST_COMMAND: >-
             python -c "import uuid, uuidv7; u = uuidv7.uuid7(); assert isinstance(u, uuid.UUID); assert u.version == 7; assert str(u).count('-') == 4"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
-          CIBW_SKIP: "pp* *-musllinux_*"
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: >-
             python -c "import uuid, uuidv7; u = uuidv7.uuid7(); assert isinstance(u, uuid.UUID); assert u.version == 7; assert str(u).count('-') == 4"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15-intel, windows-latest]
+        include:
+          - os: ubuntu-latest
+            cibw-archs-macos: auto
+          - os: macos-15-intel
+            cibw-archs-macos: x86_64
+          - os: macos-15
+            cibw-archs-macos: arm64
+          - os: windows-latest
+            cibw-archs-macos: auto
 
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +32,7 @@ jobs:
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw-archs-macos }}
           CIBW_TEST_COMMAND: >-
             python -c "import uuid, uuidv7; u = uuidv7.uuid7(); assert isinstance(u, uuid.UUID); assert u.version == 7; assert str(u).count('-') == 4"
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,60 @@
+name: Wheels
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+  workflow_dispatch:
+
+jobs:
+  wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2
+        env:
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+          CIBW_SKIP: "pp* *-musllinux_*"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_TEST_COMMAND: >-
+            python -c "import uuid, uuidv7; u = uuidv7.uuid7(); assert isinstance(u, uuid.UUID); assert u.version == 7; assert str(u).count('-') == 4"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+          retention-days: 7
+
+  sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build --sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          retention-days: 7

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
-          CIBW_SKIP: "pp* *-musllinux_*"
+          CIBW_SKIP: "*-musllinux_*"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_TEST_COMMAND: >-
             python -c "import uuid, uuidv7; u = uuidv7.uuid7(); assert isinstance(u, uuid.UUID); assert u.version == 7; assert str(u).count('-') == 4"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "pp* *-musllinux_*"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/fastuuid7.svg)](https://badge.fury.io/py/fastuuid7)
 
 A high-performance UUID v7 generation library implemented in C with Python bindings.
+The PyPI package is `fastuuid7`; the import package is `uuidv7`.
 
 ## Features
 
@@ -11,6 +12,7 @@ A high-performance UUID v7 generation library implemented in C with Python bindi
 - RFC 9562 compliant UUID v7 format
 - Python 3.8+ support
 - Thread-safe implementation
+- `uuid.uuid7()`-compatible API returning `uuid.UUID`
 - **High Performance**: See [Performance Benchmarks](#performance-benchmarks) section below
 - **Usage Examples**: See [Examples](#examples) section and [`examples/`](examples/) directory
 
@@ -45,10 +47,30 @@ from uuidv7 import uuid7
 
 # Generate a UUID v7 (matches Python's uuid.uuid7() API)
 uuid = uuid7()
-print(uuid)  # e.g., "018f1234-5678-7abc-def0-123456789abc"
+print(uuid)       # e.g., UUID('018f1234-5678-7abc-def0-123456789abc')
+print(str(uuid))  # e.g., "018f1234-5678-7abc-def0-123456789abc"
+print(uuid.time)  # Unix timestamp in milliseconds
 ```
 
-**Note**: The API matches Python's built-in `uuid.uuid7()` function (available in Python 3.14+). See [Python documentation](https://docs.python.org/3/library/uuid.html#uuid.uuid7) for details.
+**Note**: Since 0.2.0, `uuid7()` returns a `uuid.UUID` object, matching
+Python's built-in `uuid.uuid7()` function available in Python 3.14+. Use
+`str(uuid7())` when a string is needed. See
+[Python documentation](https://docs.python.org/3/library/uuid.html#uuid.uuid7)
+for details.
+
+### Fast Paths
+
+For performance-critical code that does not need a `uuid.UUID` object:
+
+```python
+from uuidv7 import uuid7_bytes, uuid7_str
+
+uuid_text = uuid7_str()
+uuid_raw = uuid7_bytes()
+```
+
+`uuid7()` remains the compatibility API. `uuid7_str()` and `uuid7_bytes()` are
+explicit fast paths.
 
 ### Examples
 
@@ -134,171 +156,52 @@ uv run python benchmarks/benchmark.py
 
 ## Performance Benchmarks
 
-### Latest Results
-
-**Test Environment:**
-- **OS**: Linux 6.8.0-90-generic
-- **CPU**: 13th Gen Intel(R) Core(TM) i7-1360P
-- **Architecture**: x86_64
-- **Python Version**: 3.14.2
-- **Iterations**: 100,000 UUID generations per implementation
-
-### Performance Summary
-
-| Implementation | UUIDs/sec | Time/UUID (μs) | Relative Speed |
-|----------------|-----------|----------------|----------------|
-| **Our C Implementation (fastuuid7)** | **501,071** | **2.00** | **1.00x** (baseline) |
-| Pure Python Implementation | 48,827 | 20.48 | **10.26x slower** |
-| Python Built-in (`uuid.uuid7`) | 47,122 | 21.22 | **10.63x slower** |
-| uuid7 Library (PyPI) | 30,263 | 33.04 | **16.56x slower** |
-
-### Detailed Results
-
-#### Our C Implementation (fastuuid7)
-
-- **Throughput**: 501,071 UUIDs/second
-- **Latency**: 2.00 microseconds per UUID
-- **Language**: C with Python bindings
-- **Package**: `fastuuid7` on PyPI
-
-**Performance Characteristics:**
-- ✅ Compiled C code for maximum performance
-- ✅ Direct system calls (`clock_gettime`) for timestamp generation
-- ✅ Minimal Python overhead
-- ✅ Thread-safe implementation
-
-#### Pure Python Implementation
-
-- **Throughput**: 48,827 UUIDs/second
-- **Latency**: 20.48 microseconds per UUID
-- **Language**: Pure Python
-
-**Performance Characteristics:**
-- Reference implementation for comparison
-- Uses Python's `time.time()` and `random` module
-- Higher overhead due to Python interpreter
-- Suitable for low-volume use cases
-
-#### Python Built-in (`uuid.uuid7`)
-
-- **Throughput**: 47,122 UUIDs/second
-- **Latency**: 21.22 microseconds per UUID
-- **Language**: C (Python standard library)
-- **Package**: Part of Python 3.14+ standard library
-- **Status**: ✅ Tested and benchmarked
-
-**Performance Characteristics:**
-- C-based implementation in Python standard library
-- Similar performance to pure Python implementations
-- Available in Python 3.14+
-- Well-integrated with Python ecosystem
-
-#### uuid7 Library (PyPI)
-
-- **Throughput**: 30,263 UUIDs/second
-- **Latency**: 33.04 microseconds per UUID
-- **Language**: Pure Python
-- **Package**: [uuid7 on PyPI](https://pypi.org/project/uuid7/) (installed as `uuid_extensions`)
-- **Status**: ✅ Tested and benchmarked
-
-**Performance Characteristics:**
-- Pure Python implementation
-- Lower performance compared to other implementations
-- Well-maintained package on PyPI
-
-### Speedup Analysis
-
-Our C implementation is:
-- **10.26x faster** than the pure Python reference implementation
-- **10.63x faster** than Python's built-in `uuid.uuid7()` (Python 3.14+)
-- **16.56x faster** than the uuid7 library from PyPI
-
-This performance advantage comes from:
-1. **Compiled code**: C code compiled to native machine code vs interpreted Python
-2. **Direct system calls**: Using `clock_gettime()` directly without Python overhead
-3. **Efficient memory management**: Pre-allocated buffers, minimal allocations
-4. **Optimized string formatting**: Using `snprintf()` efficiently
-
-### Comparison with Other Implementations
-
-All major implementations have been benchmarked and results are shown in the Performance Summary table above.
-
-### Performance Recommendations
-
-**When to Use Our C Implementation:**
-- ✅ High-throughput applications (>100K UUIDs/second)
-- ✅ Performance-critical code paths
-- ✅ Systems requiring maximum UUID generation speed
-- ✅ Applications generating millions of UUIDs
-
-**When to Use Pure Python:**
-- ✅ Low-volume use cases (<10K UUIDs/second)
-- ✅ Prototyping and development
-- ✅ Applications where ease of deployment is more important than performance
-- ✅ Environments where C extensions cannot be installed
-
-### Running Benchmarks
-
-To run benchmarks on your system:
+Run benchmarks before release and before making speed claims:
 
 ```bash
-# Install the package in development mode
-uv pip install -e .
-
-# Run benchmarks
-python benchmarks/benchmark.py
-
-# Or using uv
-uv run python benchmarks/benchmark.py
+python benchmarks/benchmark.py --output benchmarks/results-0.2.0-local.md
+python benchmarks/clock_sources.py --output benchmarks/clock-results-0.2.0-local.md
 ```
 
-### Benchmark Methodology
+The benchmark reports environment details, UUIDs/second, and ns/op for:
 
-The benchmark follows these steps:
+- `uuidv7.uuid7()` returning `uuid.UUID`
+- `uuidv7.uuid7_str()`
+- `uuidv7.uuid7_bytes()`
+- `str(uuidv7.uuid7())`
+- Python stdlib `uuid.uuid7()` when available
+- published `fastuuid7==0.1.0` in an isolated temporary environment
+- optional competitors when installed: `uuid-utils`, `fastuuidv7`, and `uuid7`
 
-1. **Warmup Phase**: Each implementation runs 1,000 iterations to warm up CPU caches
-2. **Measurement Phase**: 100,000 UUID generations are timed using `time.perf_counter()`
-3. **Validation**: Each generated UUID is validated for:
-   - Correct length (36 characters)
-   - Correct format (4 hyphens)
-   - Valid UUID v7 structure (version field = 7, variant field = 8/9/a/b)
-
-**Metrics Calculated:**
-- **UUIDs/second**: Throughput metric showing how many UUIDs can be generated per second
-- **Time/UUID (μs)**: Latency metric showing microseconds per UUID generation
-- **Speedup**: Relative performance compared to the fastest implementation
-
-### Other Implementations
-
-Additional UUID v7 implementations that exist but were not benchmarked in this test:
-
-- **uuid7 Library**: 
-  - [PyPI package](https://pypi.org/project/uuid7/)
-  - Pure Python implementation
-  - See [Comparison with Other Implementations](#comparison-with-other-implementations) section above for status
-
-**Note**: To add these implementations to benchmarks, install them and run `python benchmarks/benchmark.py`. The benchmark script will automatically detect and test available implementations.
+The 0.2.0 release should not be tagged or published until benchmark results are
+reviewed.
 
 ## CI/CD
 
 This project uses GitHub Actions for continuous integration and deployment:
 
 - **CI Pipeline** (`.github/workflows/ci.yml`):
-  - Runs tests on Python 3.8, 3.9, 3.10, 3.11, 3.12, and 3.13
+  - Runs tests on Python 3.8 through 3.14
   - Runs linting with ruff
   - Builds the package to verify it compiles correctly
   - Triggers on push and pull requests
 
+- **Wheel Pipeline** (`.github/workflows/wheels.yml`):
+  - Builds wheels with cibuildwheel for Linux, macOS, and Windows
+  - Verifies installed wheels can import `uuidv7` and generate UUIDv7 values
+
 - **Publish Pipeline** (`.github/workflows/publish.yml`):
   - Automatically publishes to PyPI when a new release is created
+  - Builds platform wheels with cibuildwheel plus an sdist before publishing
   - Uses trusted publishing (no API tokens required)
   - Can be manually triggered via workflow_dispatch
 
 ### Publishing a New Release
 
-1. Update the version in `pyproject.toml` and `uuidv7/__init__.py`
-2. Create a new [GitHub Release](https://github.com/nekrasovp/uuidv7/releases/new)
-3. The workflow will automatically build and publish to PyPI
+1. Run tests, builds, and benchmarks.
+2. Review benchmark results and decide whether optimization is needed.
+3. Create a new [GitHub Release](https://github.com/nekrasovp/uuidv7/releases/new).
+4. The workflow will automatically build and publish to PyPI.
 
 ## License
 

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1,167 +1,332 @@
-"""Benchmark script to compare UUID v7 implementations."""
+"""Benchmark UUID v7 implementations."""
 
-import random
-import struct
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import os
+import platform
+import shutil
+import subprocess
 import sys
+import tempfile
+import textwrap
 import time
-from typing import Callable
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
 
-# Our implementation
-from uuidv7 import uuid7 as our_uuid7
+from uuidv7 import uuid7 as fastuuid7_uuid7
+from uuidv7 import uuid7_bytes as fastuuid7_uuid7_bytes
+from uuidv7 import uuid7_str as fastuuid7_uuid7_str
 
-# Try to import Python's built-in UUID v7 (Python 3.13+)
-try:
-    import uuid
+DEFAULT_ITERATIONS = 1_000_000
+WARMUP_ITERATIONS = 1_000
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    version: str
+    iterations: int
+    total_seconds: float
+    uuids_per_second: float
+    ns_per_op: float
+
+
+@dataclass
+class BenchmarkCase:
+    name: str
+    version: str
+    func: Callable[[], object]
+
+
+def package_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not installed"
+
+
+def validate_uuid7(value: object) -> None:
+    if isinstance(value, uuid.UUID):
+        parsed = value
+    elif isinstance(value, bytes):
+        parsed = uuid.UUID(bytes=value)
+    else:
+        parsed = uuid.UUID(str(value))
+    if parsed.version != 7:
+        raise AssertionError(f"{value!r} is not UUIDv7")
+    if parsed.variant != uuid.RFC_4122:
+        raise AssertionError(f"{value!r} is not RFC-compatible")
+
+
+def benchmark_case(case: BenchmarkCase, iterations: int) -> BenchmarkResult:
+    for _ in range(WARMUP_ITERATIONS):
+        validate_uuid7(case.func())
+
+    start = time.perf_counter_ns()
+    for _ in range(iterations):
+        case.func()
+    end = time.perf_counter_ns()
+
+    validate_uuid7(case.func())
+
+    total_ns = end - start
+    total_seconds = total_ns / 1_000_000_000
+    return BenchmarkResult(
+        name=case.name,
+        version=case.version,
+        iterations=iterations,
+        total_seconds=total_seconds,
+        uuids_per_second=iterations / total_seconds,
+        ns_per_op=total_ns / iterations,
+    )
+
+
+def optional_case(
+    package_name: str,
+    import_name: str,
+    function_name: str,
+    display_name: str,
+) -> Optional[BenchmarkCase]:
+    try:
+        module = __import__(import_name, fromlist=[function_name])
+        func = getattr(module, function_name)
+    except (AttributeError, ImportError):
+        return None
+
+    return BenchmarkCase(
+        name=display_name,
+        version=package_version(package_name),
+        func=func,
+    )
+
+
+def current_process_cases() -> list[BenchmarkCase]:
+    cases = [
+        BenchmarkCase(
+            name="fastuuid7 0.2.0 candidate: uuid7() -> uuid.UUID",
+            version=package_version("fastuuid7"),
+            func=fastuuid7_uuid7,
+        ),
+        BenchmarkCase(
+            name="fastuuid7 0.2.0 candidate: uuid7_str() -> str",
+            version=package_version("fastuuid7"),
+            func=fastuuid7_uuid7_str,
+        ),
+        BenchmarkCase(
+            name="fastuuid7 0.2.0 candidate: uuid7_bytes() -> bytes",
+            version=package_version("fastuuid7"),
+            func=fastuuid7_uuid7_bytes,
+        ),
+        BenchmarkCase(
+            name="fastuuid7 0.2.0 candidate: str(uuid7())",
+            version=package_version("fastuuid7"),
+            func=lambda: str(fastuuid7_uuid7()),
+        ),
+    ]
 
     if hasattr(uuid, "uuid7"):
-
-        def python_builtin_uuid7() -> str:
-            """Python's built-in UUID v7 (Python 3.13+)."""
-            return str(uuid.uuid7())
-
-        HAS_BUILTIN = True
-    else:
-        HAS_BUILTIN = False
-        python_builtin_uuid7 = None
-except (AttributeError, ImportError):
-    HAS_BUILTIN = False
-    python_builtin_uuid7 = None
-
-
-# Pure Python implementation for comparison
-def pure_python_uuid7() -> str:
-    """Pure Python UUID v7 implementation."""
-    # Get current time in milliseconds
-    now_ms = int(time.time() * 1000)
-
-    # Generate random bytes (need 10 bytes for 5 uint16 values)
-    rand_bytes = bytes([random.randint(0, 255) for _ in range(10)])
-
-    # Pack timestamp (48 bits) and random (80 bits)
-    # Format: timestamp_ms (48 bits) | version (4 bits) | rand_a (12 bits)
-    #         variant (2 bits) | rand_b (14 bits) | rand_c (16 bits) | rand_d (16 bits)
-    timestamp_high = (now_ms >> 28) & 0xFFFFFFFF
-    timestamp_low = (now_ms >> 12) & 0xFFFF
-
-    rand_a = struct.unpack(">H", rand_bytes[0:2])[0] & 0x0FFF | 0x7000
-    rand_b = struct.unpack(">H", rand_bytes[2:4])[0] & 0x3FFF | 0x8000
-    rand_c = struct.unpack(">H", rand_bytes[4:6])[0]
-    rand_d = struct.unpack(">H", rand_bytes[6:8])[0]
-    rand_e = struct.unpack(">H", rand_bytes[8:10])[0]
-
-    return f"{timestamp_high:08x}-{timestamp_low:04x}-{rand_a:04x}-{rand_b:04x}-{rand_c:04x}{rand_d:04x}{rand_e:04x}"
-
-
-# Try to import uuid7 library if available (from uuid_extensions package)
-try:
-    from uuid_extensions import uuid7 as uuid7_func
-
-    def uuid7_library() -> str:
-        """uuid7 library from PyPI (uuid_extensions package)."""
-        return str(uuid7_func())
-
-    HAS_UUID7_LIB = True
-except ImportError:
-    HAS_UUID7_LIB = False
-    uuid7_library = None
-
-
-def benchmark(func: Callable[[], str], name: str, iterations: int = 100000) -> dict:
-    """Benchmark a UUID generation function."""
-    # Warmup
-    for _ in range(1000):
-        func()
-
-    # Actual benchmark
-    start = time.perf_counter()
-    for _ in range(iterations):
-        uuid_val = func()
-        # Verify it's a valid UUID format
-        assert len(uuid_val) == 36
-        assert uuid_val.count("-") == 4
-    end = time.perf_counter()
-
-    total_time = end - start
-    time_per_uuid = total_time / iterations
-    uuids_per_second = iterations / total_time
-
-    return {
-        "name": name,
-        "total_time": total_time,
-        "time_per_uuid_us": time_per_uuid * 1_000_000,  # microseconds
-        "uuids_per_second": uuids_per_second,
-        "iterations": iterations,
-    }
-
-
-def run_benchmarks():
-    """Run all benchmarks and print results."""
-    iterations = 100000
-    print(f"Running benchmarks with {iterations:,} iterations per implementation...")
-    print("=" * 80)
-
-    results = []
-
-    # Our C implementation
-    print("Benchmarking: Our C Implementation (fastuuid7)...")
-    results.append(benchmark(our_uuid7, "Our C Implementation (fastuuid7)", iterations))
-    print(f"  ✓ Completed: {results[-1]['uuids_per_second']:,.0f} UUIDs/sec")
-
-    # Python built-in (if available)
-    if HAS_BUILTIN:
-        print("Benchmarking: Python Built-in (uuid.uuid7)...")
-        results.append(benchmark(python_builtin_uuid7, "Python Built-in (uuid.uuid7)", iterations))
-        print(f"  ✓ Completed: {results[-1]['uuids_per_second']:,.0f} UUIDs/sec")
-    else:
-        print("  ⚠ Python built-in UUID v7 not available (requires Python 3.13+)")
-
-    # Pure Python implementation
-    print("Benchmarking: Pure Python Implementation...")
-    results.append(benchmark(pure_python_uuid7, "Pure Python Implementation", iterations))
-    print(f"  ✓ Completed: {results[-1]['uuids_per_second']:,.0f} UUIDs/sec")
-
-    # uuid7 library (if available)
-    if HAS_UUID7_LIB:
-        print("Benchmarking: uuid7 Library (PyPI)...")
-        results.append(benchmark(uuid7_library, "uuid7 Library (PyPI)", iterations))
-        print(f"  ✓ Completed: {results[-1]['uuids_per_second']:,.0f} UUIDs/sec")
-    else:
-        print("  ⚠ uuid7 library not installed (pip install uuid7)")
-
-    print("\n" + "=" * 80)
-    print("RESULTS SUMMARY")
-    print("=" * 80)
-    print(f"{'Implementation':<35} {'UUIDs/sec':>15} {'Time/UUID (μs)':>18}")
-    print("-" * 80)
-
-    # Sort by performance
-    results.sort(key=lambda x: x["uuids_per_second"], reverse=True)
-
-    for result in results:
-        print(
-            f"{result['name']:<35} {result['uuids_per_second']:>15,.0f} {result['time_per_uuid_us']:>18.2f}"
+        cases.append(
+            BenchmarkCase(
+                name="Python stdlib uuid.uuid7()",
+                version=platform.python_version(),
+                func=uuid.uuid7,
+            )
         )
 
-    # Calculate speedup
-    if len(results) > 1:
-        fastest = results[0]
-        print("\n" + "=" * 80)
-        print("SPEEDUP COMPARISON")
-        print("=" * 80)
-        for result in results[1:]:
-            speedup = fastest["uuids_per_second"] / result["uuids_per_second"]
-            print(f"{fastest['name']} is {speedup:.2f}x faster than {result['name']}")
+    for case in (
+        optional_case("uuid-utils", "uuid_utils", "uuid7", "uuid-utils uuid7()"),
+        optional_case("fastuuidv7", "fastuuidv7", "uuid7", "fastuuidv7 uuid7()"),
+        optional_case("uuid7", "uuid_extensions", "uuid7", "uuid7 package uuid_extensions.uuid7()"),
+    ):
+        if case is not None:
+            cases.append(case)
 
-    return results
+    return cases
+
+
+def benchmark_published_fastuuid7(iterations: int) -> Optional[BenchmarkResult]:
+    python = sys.executable
+    with tempfile.TemporaryDirectory(prefix="fastuuid7-0.1.0-bench-") as tmp:
+        venv_dir = Path(tmp) / "venv"
+        subprocess.run([python, "-m", "venv", str(venv_dir)], check=True, stdout=subprocess.PIPE)
+        venv_python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+        install = subprocess.run(
+            [
+                str(venv_python),
+                "-m",
+                "pip",
+                "install",
+                "--quiet",
+                "fastuuid7==0.1.0",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=tmp,
+        )
+        if install.returncode != 0:
+            print("Skipping published fastuuid7==0.1.0 benchmark; install failed:", file=sys.stderr)
+            print(install.stderr.strip(), file=sys.stderr)
+            return None
+
+        script = textwrap.dedent(
+            f"""
+            import json
+            import time
+            import uuid
+            import importlib.metadata
+            from uuidv7 import uuid7
+
+            iterations = {iterations}
+            for _ in range(1000):
+                value = uuid7()
+                parsed = uuid.UUID(str(value))
+                assert parsed.version == 7
+
+            start = time.perf_counter_ns()
+            for _ in range(iterations):
+                uuid7()
+            end = time.perf_counter_ns()
+
+            total_ns = end - start
+            print(json.dumps({{
+                "name": "published fastuuid7 0.1.0: uuid7() -> str",
+                "version": importlib.metadata.version("fastuuid7"),
+                "iterations": iterations,
+                "total_seconds": total_ns / 1_000_000_000,
+                "uuids_per_second": iterations / (total_ns / 1_000_000_000),
+                "ns_per_op": total_ns / iterations,
+            }}))
+            """
+        )
+        run = subprocess.run(
+            [str(venv_python), "-c", script],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=tmp,
+        )
+        if run.returncode != 0:
+            print(
+                "Skipping published fastuuid7==0.1.0 benchmark; benchmark failed:", file=sys.stderr
+            )
+            print(run.stderr.strip(), file=sys.stderr)
+            return None
+
+    data = json.loads(run.stdout)
+    return BenchmarkResult(**data)
+
+
+def environment_markdown() -> str:
+    cpu = platform.processor() or "unknown"
+    return "\n".join(
+        [
+            "## Environment",
+            "",
+            f"- OS: {platform.platform()}",
+            f"- Machine: {platform.machine()}",
+            f"- CPU: {cpu}",
+            f"- Python: {platform.python_version()}",
+        ]
+    )
+
+
+def results_markdown(results: list[BenchmarkResult]) -> str:
+    lines = [
+        "## Results",
+        "",
+        "| Implementation | Version | UUIDs/sec | ns/op | Iterations |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    for result in sorted(results, key=lambda item: item.uuids_per_second, reverse=True):
+        lines.append(
+            f"| {result.name} | {result.version} | {result.uuids_per_second:,.0f} | {result.ns_per_op:,.1f} | {result.iterations:,} |"
+        )
+    return "\n".join(lines)
+
+
+def skipped_markdown(results: list[BenchmarkResult]) -> str:
+    measured = {result.name for result in results}
+    optional = [
+        "Python stdlib uuid.uuid7()",
+        "uuid-utils uuid7()",
+        "fastuuidv7 uuid7()",
+        "uuid7 package uuid_extensions.uuid7()",
+        "published fastuuid7 0.1.0: uuid7() -> str",
+    ]
+    skipped = [name for name in optional if name not in measured]
+    if not skipped:
+        return ""
+    lines = ["## Skipped", ""]
+    lines.extend(f"- {name}" for name in skipped)
+    return "\n".join(lines)
+
+
+def write_markdown(output: Path, results: list[BenchmarkResult]) -> None:
+    parts = [
+        "# UUIDv7 Benchmark Results",
+        "",
+        environment_markdown(),
+        "",
+        results_markdown(results),
+    ]
+    skipped = skipped_markdown(results)
+    if skipped:
+        parts.extend(["", skipped])
+    output.write_text("\n".join(parts) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-n",
+        "--iterations",
+        type=int,
+        default=DEFAULT_ITERATIONS,
+        help=f"iterations per implementation, default {DEFAULT_ITERATIONS}",
+    )
+    parser.add_argument(
+        "--skip-published",
+        action="store_true",
+        help="skip temporary-venv benchmark for published fastuuid7==0.1.0",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write Markdown results to this path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    results = [benchmark_case(case, args.iterations) for case in current_process_cases()]
+
+    if not args.skip_published and shutil.which(sys.executable):
+        published = benchmark_published_fastuuid7(args.iterations)
+        if published is not None:
+            results.append(published)
+
+    print(environment_markdown())
+    print()
+    print(results_markdown(results))
+    skipped = skipped_markdown(results)
+    if skipped:
+        print()
+        print(skipped)
+
+    if args.output:
+        write_markdown(args.output, results)
+        print()
+        print(f"Wrote {args.output}")
+
+    return 0
 
 
 if __name__ == "__main__":
-    try:
-        results = run_benchmarks()
-        sys.exit(0)
-    except Exception as e:
-        print(f"Error running benchmarks: {e}", file=sys.stderr)
-        import traceback
-
-        traceback.print_exc()
-        sys.exit(1)
+    raise SystemExit(main())

--- a/benchmarks/clock-results-0.2.0-local.md
+++ b/benchmarks/clock-results-0.2.0-local.md
@@ -1,0 +1,15 @@
+# UUIDv7 Clock Source Benchmark
+
+## Environment
+
+- OS: Linux-5.15.167.4-microsoft-standard-WSL2-x86_64-with-glibc2.39
+- Machine: x86_64
+- CPU: x86_64
+- Python: 3.12.3
+
+## Results
+
+| Clock source | ns/call | Iterations |
+| --- | ---: | ---: |
+| clock_gettime(CLOCK_REALTIME_COARSE) | 2.910 | 10,000,000 |
+| clock_gettime(CLOCK_REALTIME) | 14.538 | 10,000,000 |

--- a/benchmarks/clock_sources.py
+++ b/benchmarks/clock_sources.py
@@ -1,0 +1,253 @@
+"""Benchmark wall-clock sources used by UUIDv7 generation."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ITERATIONS = 10_000_000
+
+
+POSIX_SOURCE = r"""
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static inline uint64_t monotonic_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static inline uint64_t realtime_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000);
+}
+
+#ifdef CLOCK_REALTIME_COARSE
+static inline uint64_t realtime_coarse_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000);
+}
+#endif
+
+static void bench_realtime(int iterations, volatile uint64_t *sink) {
+    uint64_t start = monotonic_ns();
+    for (int i = 0; i < iterations; ++i) {
+        *sink ^= realtime_ms();
+    }
+    uint64_t end = monotonic_ns();
+    printf("clock_gettime(CLOCK_REALTIME),%.3f\n", (double)(end - start) / iterations);
+}
+
+#ifdef CLOCK_REALTIME_COARSE
+static void bench_realtime_coarse(int iterations, volatile uint64_t *sink) {
+    uint64_t start = monotonic_ns();
+    for (int i = 0; i < iterations; ++i) {
+        *sink ^= realtime_coarse_ms();
+    }
+    uint64_t end = monotonic_ns();
+    printf("clock_gettime(CLOCK_REALTIME_COARSE),%.3f\n", (double)(end - start) / iterations);
+}
+#endif
+
+int main(int argc, char **argv) {
+    int iterations = argc > 1 ? atoi(argv[1]) : 10000000;
+    volatile uint64_t sink = 0;
+    bench_realtime(iterations, &sink);
+#ifdef CLOCK_REALTIME_COARSE
+    bench_realtime_coarse(iterations, &sink);
+#endif
+    if (sink == 42) {
+        printf("sink,%llu\n", (unsigned long long)sink);
+    }
+    return 0;
+}
+"""
+
+
+WINDOWS_SOURCE = r"""
+#define WIN32_LEAN_AND_MEAN
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+
+typedef VOID (WINAPI *GetSystemTimePreciseAsFileTimeFn)(LPFILETIME);
+
+static inline uint64_t qpc_ns(LARGE_INTEGER frequency) {
+    LARGE_INTEGER counter;
+    QueryPerformanceCounter(&counter);
+    return (uint64_t)((counter.QuadPart * 1000000000ULL) / frequency.QuadPart);
+}
+
+static inline uint64_t filetime_ms(FILETIME ft) {
+    ULARGE_INTEGER uli;
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (uli.QuadPart - 116444736000000000ULL) / 10000ULL;
+}
+
+static void bench_precise(
+    int iterations,
+    LARGE_INTEGER frequency,
+    GetSystemTimePreciseAsFileTimeFn precise,
+    volatile uint64_t *sink
+) {
+    FILETIME ft;
+    uint64_t start = qpc_ns(frequency);
+    for (int i = 0; i < iterations; ++i) {
+        precise(&ft);
+        *sink ^= filetime_ms(ft);
+    }
+    uint64_t end = qpc_ns(frequency);
+    printf("GetSystemTimePreciseAsFileTime,%.3f\n", (double)(end - start) / iterations);
+}
+
+static void bench_filetime(int iterations, LARGE_INTEGER frequency, volatile uint64_t *sink) {
+    FILETIME ft;
+    uint64_t start = qpc_ns(frequency);
+    for (int i = 0; i < iterations; ++i) {
+        GetSystemTimeAsFileTime(&ft);
+        *sink ^= filetime_ms(ft);
+    }
+    uint64_t end = qpc_ns(frequency);
+    printf("GetSystemTimeAsFileTime,%.3f\n", (double)(end - start) / iterations);
+}
+
+int main(int argc, char **argv) {
+    int iterations = argc > 1 ? atoi(argv[1]) : 10000000;
+    volatile uint64_t sink = 0;
+    LARGE_INTEGER frequency;
+    HMODULE kernel32;
+    GetSystemTimePreciseAsFileTimeFn precise = NULL;
+
+    QueryPerformanceFrequency(&frequency);
+    kernel32 = GetModuleHandleA("kernel32.dll");
+    if (kernel32 != NULL) {
+        precise = (GetSystemTimePreciseAsFileTimeFn)GetProcAddress(
+            kernel32, "GetSystemTimePreciseAsFileTime"
+        );
+    }
+
+    if (precise != NULL) {
+        bench_precise(iterations, frequency, precise, &sink);
+    }
+    bench_filetime(iterations, frequency, &sink);
+    if (sink == 42) {
+        printf("sink,%llu\n", (unsigned long long)sink);
+    }
+    return 0;
+}
+"""
+
+
+@dataclass
+class ClockResult:
+    source: str
+    ns_per_call: float
+
+
+def compiler_command(source: Path, output: Path) -> list[str]:
+    if os.name == "nt":
+        cl = shutil.which("cl")
+        if cl is None:
+            raise RuntimeError("MSVC cl.exe is required on Windows")
+        return [cl, "/O2", "/nologo", str(source), f"/Fe:{output}"]
+
+    cc = shutil.which("cc") or shutil.which("gcc") or shutil.which("clang")
+    if cc is None:
+        raise RuntimeError("A C compiler is required")
+    return [cc, "-O3", str(source), "-o", str(output)]
+
+
+def run_benchmark(iterations: int) -> list[ClockResult]:
+    with tempfile.TemporaryDirectory(prefix="uuidv7-clock-bench-") as tmp:
+        tmpdir = Path(tmp)
+        source = tmpdir / ("clock_sources.c")
+        output = tmpdir / ("clock_sources.exe" if os.name == "nt" else "clock_sources")
+        source.write_text(WINDOWS_SOURCE if os.name == "nt" else POSIX_SOURCE, encoding="utf-8")
+        subprocess.run(compiler_command(source, output), check=True, cwd=tmpdir)
+        run = subprocess.run(
+            [str(output), str(iterations)],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            cwd=tmpdir,
+        )
+
+    results = []
+    for line in run.stdout.splitlines():
+        name, value = line.split(",", 1)
+        if name != "sink":
+            results.append(ClockResult(source=name, ns_per_call=float(value)))
+    return results
+
+
+def environment_markdown() -> str:
+    return "\n".join(
+        [
+            "## Environment",
+            "",
+            f"- OS: {platform.platform()}",
+            f"- Machine: {platform.machine()}",
+            f"- CPU: {platform.processor() or 'unknown'}",
+            f"- Python: {platform.python_version()}",
+        ]
+    )
+
+
+def results_markdown(results: list[ClockResult], iterations: int) -> str:
+    lines = [
+        "## Results",
+        "",
+        "| Clock source | ns/call | Iterations |",
+        "| --- | ---: | ---: |",
+    ]
+    for result in sorted(results, key=lambda item: item.ns_per_call):
+        lines.append(f"| {result.source} | {result.ns_per_call:,.3f} | {iterations:,} |")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-n",
+        "--iterations",
+        type=int,
+        default=DEFAULT_ITERATIONS,
+        help=f"iterations per source, default {DEFAULT_ITERATIONS}",
+    )
+    parser.add_argument("--output", type=Path, help="write Markdown results to this path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    results = run_benchmark(args.iterations)
+    report = "\n\n".join(
+        [
+            "# UUIDv7 Clock Source Benchmark",
+            environment_markdown(),
+            results_markdown(results, args.iterations),
+        ]
+    )
+    print(report)
+    if args.output:
+        args.output.write_text(report + "\n", encoding="utf-8")
+        print()
+        print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results-0.2.0-local.md
+++ b/benchmarks/results-0.2.0-local.md
@@ -1,0 +1,25 @@
+# UUIDv7 Benchmark Results
+
+## Environment
+
+- OS: Linux-5.15.167.4-microsoft-standard-WSL2-x86_64-with-glibc2.39
+- Machine: x86_64
+- CPU: x86_64
+- Python: 3.12.3
+
+## Results
+
+| Implementation | Version | UUIDs/sec | ns/op | Iterations |
+| --- | ---: | ---: | ---: | ---: |
+| fastuuidv7 uuid7() | 0.1.5 | 23,095,658 | 43.3 | 1,000,000 |
+| fastuuid7 0.2.0 candidate: uuid7_bytes() -> bytes | 0.2.0 | 18,203,404 | 54.9 | 1,000,000 |
+| fastuuid7 0.2.0 candidate: uuid7_str() -> str | 0.2.0 | 13,880,113 | 72.0 | 1,000,000 |
+| uuid-utils uuid7() | 0.16.0 | 12,186,695 | 82.1 | 1,000,000 |
+| fastuuid7 0.2.0 candidate: uuid7() -> uuid.UUID | 0.2.0 | 4,366,928 | 229.0 | 1,000,000 |
+| published fastuuid7 0.1.0: uuid7() -> str | 0.1.0 | 4,298,579 | 232.6 | 1,000,000 |
+| fastuuid7 0.2.0 candidate: str(uuid7()) | 0.2.0 | 1,479,025 | 676.1 | 1,000,000 |
+| uuid7 package uuid_extensions.uuid7() | 0.1.0 | 762,942 | 1,310.7 | 1,000,000 |
+
+## Skipped
+
+- Python stdlib uuid.uuid7()

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ This directory contains practical examples demonstrating how to use the `fastuui
 Basic usage examples including:
 - Single UUID generation
 - Multiple UUID generation
+- `uuid.UUID` object attributes such as `version`, `variant`, and `time`
 - UUID format validation
 - Performance demonstration
 
@@ -34,6 +35,7 @@ python examples/batch_generation.py
 Database integration examples:
 - Using UUID v7 as primary keys
 - Time-ordered UUIDs for database records
+- Timestamp extraction with `uuid.UUID.time`
 - SQL insert examples
 
 **Run:**
@@ -73,4 +75,3 @@ python examples/database_usage.py
 
 - Python 3.8+
 - `fastuuid7` package installed (see main README for installation)
-

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,5 +1,7 @@
 """Basic usage example for fastuuid7 library."""
 
+import uuid as uuid_module
+
 from uuidv7 import uuid7
 
 
@@ -10,25 +12,30 @@ def main():
 
     # Generate a single UUID
     print("\n1. Generate a single UUID v7:")
-    uuid = uuid7()
-    print(f"   UUID: {uuid}")
+    value = uuid7()
+    print(f"   UUID object: {value!r}")
+    print(f"   UUID string: {value}")
+    print(f"   Timestamp: {value.time} ms")
 
     # Generate multiple UUIDs
     print("\n2. Generate multiple UUIDs:")
     uuids = [uuid7() for _ in range(5)]
-    for i, uuid_val in enumerate(uuids, 1):
-        print(f"   {i}. {uuid_val}")
+    for i, value in enumerate(uuids, 1):
+        print(f"   {i}. {value}")
 
     # Verify UUID format
     print("\n3. Verify UUID format:")
     sample_uuid = uuid7()
+    sample_text = str(sample_uuid)
     print(f"   UUID: {sample_uuid}")
-    print(f"   Length: {len(sample_uuid)} characters")
+    print(f"   Type: {type(sample_uuid).__name__}")
+    print(f"   isinstance(uuid.UUID): {isinstance(sample_uuid, uuid_module.UUID)}")
+    print(f"   Length: {len(sample_text)} characters")
     print(
-        f"   Format: {'✓ Valid' if len(sample_uuid) == 36 and sample_uuid.count('-') == 4 else '✗ Invalid'}"
+        f"   Format: {'Valid' if len(sample_text) == 36 and sample_text.count('-') == 4 else 'Invalid'}"
     )
-    print(f"   Version field (13th char): {sample_uuid[14]} (should be '7')")
-    print(f"   Variant field (17th char): {sample_uuid[19]} (should be 8/9/a/b)")
+    print(f"   Version: {sample_uuid.version}")
+    print(f"   Variant: {sample_uuid.variant}")
 
     # Performance demonstration
     print("\n4. Performance demonstration:")

--- a/examples/batch_generation.py
+++ b/examples/batch_generation.py
@@ -1,16 +1,20 @@
 """Example of batch UUID v7 generation for high-throughput scenarios."""
 
+from __future__ import annotations
+
+import uuid
+
 from uuidv7 import uuid7
 
 
-def generate_batch(count: int) -> list[str]:
+def generate_batch(count: int) -> list[uuid.UUID]:
     """Generate a batch of UUID v7 values.
 
     Args:
         count: Number of UUIDs to generate
 
     Returns:
-        List of UUID strings
+        List of UUID objects
     """
     return [uuid7() for _ in range(count)]
 
@@ -39,9 +43,7 @@ def main():
     print("\n3. Demonstrate timestamp ordering (first 10):")
     batch = generate_batch(10)
     for i, uuid_val in enumerate(batch, 1):
-        # Extract timestamp part (first segment)
-        timestamp_part = uuid_val.split("-")[0]
-        print(f"   {i:2d}. {uuid_val} (timestamp: {timestamp_part})")
+        print(f"   {i:2d}. {uuid_val} (timestamp_ms: {uuid_val.time})")
 
 
 if __name__ == "__main__":

--- a/examples/database_usage.py
+++ b/examples/database_usage.py
@@ -1,5 +1,7 @@
 """Example of using fastuuid7 for database primary keys."""
 
+import uuid
+
 from uuidv7 import uuid7
 
 
@@ -11,19 +13,9 @@ class User:
         self.id = uuid7()
         self.name = name
         self.email = email
-        self.created_at = self._extract_timestamp()
+        self.created_at = self.id.time
 
-    def _extract_timestamp(self) -> int:
-        """Extract timestamp from UUID v7 (approximate).
-
-        Note: This is a simplified extraction. For accurate timestamp
-        extraction, use proper UUID v7 parsing.
-        """
-        # UUID v7 format: timestamp_ms (48 bits) in first two segments
-        parts = self.id.split("-")
-        timestamp_hex = parts[0] + parts[1]
-        # This is approximate - actual extraction requires proper bit manipulation
-        return int(timestamp_hex, 16)
+    id: uuid.UUID
 
     def __repr__(self) -> str:
         """String representation of User."""
@@ -50,7 +42,7 @@ def main():
     print("\n2. Users sorted by creation time (UUID v7 is time-ordered):")
     sorted_users = sorted(users, key=lambda u: u.id)
     for user in sorted_users:
-        print(f"   {user.id} - {user.name}")
+        print(f"   {user.id} - {user.name} ({user.created_at})")
 
     # Simulate database insert
     print("\n3. Simulate database insert operations:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77.0.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,8 +8,7 @@ version = "0.2.0"
 description = "UUID v7 generation package using a C library"
 readme = "README.md"
 requires-python = ">=3.8"
-license = "MIT"
-license-files = ["LICENSE"]
+license = {text = "MIT"}
 authors = [
     {name = "Pavel Nekrasov", email = "nekrasovp@gmail.com"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,39 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastuuid7"
-version = "0.1.0"
+version = "0.2.0"
 description = "UUID v7 generation package using a C library"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Pavel Nekrasov", email = "nekrasovp@gmail.com"}
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: C",
-    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
 ]
 keywords = ["uuid", "uuidv7", "uuid-v7", "identifier"]
 dependencies = []
 
 [project.optional-dependencies]
 dev = [
+    "build>=1.2.0",
+    "cibuildwheel>=2.23.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
@@ -57,6 +69,8 @@ select = [
 ignore = [
     "E501",  # line too long, handled by formatter
     "B008",  # do not perform function calls in argument defaults
+    "UP022", # capture_output would hide stdout/stderr intent in subprocess calls
+    "UP045", # keep Optional syntax for Python 3.8 parser compatibility
 ]
 
 [tool.ruff.lint.isort]
@@ -73,7 +87,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short --capture=no"
 
 [tool.coverage.run]
 source = ["uuidv7"]
@@ -88,4 +102,3 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
 ]
-

--- a/setup.py
+++ b/setup.py
@@ -3,25 +3,6 @@
 import os
 
 from setuptools import Extension, setup
-from wheel.bdist_wheel import bdist_wheel
-
-
-class BinaryDistribution(bdist_wheel):
-    """Custom bdist_wheel to fix platform tag."""
-
-    def finalize_options(self):
-        bdist_wheel.finalize_options(self)
-        # Mark as not pure to allow platform-specific wheels
-        self.root_is_pure = False
-
-    def get_tag(self):
-        """Override tag to use manylinux instead of linux_x86_64."""
-        python, abi, plat = bdist_wheel.get_tag(self)
-        # Replace linux_x86_64 with manylinux2014_x86_64 for PyPI compatibility
-        if plat.startswith("linux_"):
-            plat = plat.replace("linux_", "manylinux2014_")
-        return python, abi, plat
-
 
 uuidv7_extension = Extension(
     "uuidv7.uuidv7_impl.uuid7_gen",
@@ -30,10 +11,8 @@ uuidv7_extension = Extension(
         os.path.join("uuidv7", "uuidv7_impl", "src", "uuid7_gen.c"),
     ],
     include_dirs=[os.path.join("uuidv7", "uuidv7_impl", "include")],
-    libraries=["rt"],  # For clock_gettime on Linux
 )
 
 setup(
     ext_modules=[uuidv7_extension],
-    cmdclass={"bdist_wheel": BinaryDistribution},
 )

--- a/tests/test_uuidv7.py
+++ b/tests/test_uuidv7.py
@@ -1,35 +1,45 @@
 """Tests for UUID v7 generation functionality."""
 
 import re
+import time
+import uuid
 
-from uuidv7 import uuid7
+from uuidv7 import uuid7, uuid7_bytes, uuid7_str
+from uuidv7.uuidv7_impl.uuid7_gen import (
+    _generate_uuid7_bytes_for_tests,
+    _reset_state_for_tests,
+)
+
+UUID7_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _timestamp_ms(value: uuid.UUID) -> int:
+    return value.int >> 80
 
 
 def test_uuid_format():
     """Test that generated UUIDs match the UUID v7 format."""
-    uuid = uuid7()
+    value = uuid7()
 
-    # UUID v7 format: 8-4-4-4-12 hexadecimal digits
-    uuid_pattern = re.compile(
-        r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", re.IGNORECASE
-    )
-
-    assert uuid_pattern.match(uuid), f"UUID {uuid} does not match UUID v7 format"
-    assert len(uuid) == 36, f"UUID length should be 36, got {len(uuid)}"
+    assert UUID7_PATTERN.match(str(value)), f"UUID {value} does not match UUID v7 format"
+    assert len(str(value)) == 36, f"UUID length should be 36, got {len(str(value))}"
 
 
 def test_uuid_version_field():
     """Test that the version field (13th character) is '7'."""
-    uuid = uuid7()
-    parts = uuid.split("-")
+    value = str(uuid7())
+    parts = value.split("-")
     assert len(parts) == 5, "UUID should have 5 parts"
     assert parts[2][0] == "7", f"Version field should be '7', got '{parts[2][0]}'"
 
 
 def test_uuid_variant_field():
     """Test that the variant field (17th character) is 8, 9, a, or b."""
-    uuid = uuid7()
-    parts = uuid.split("-")
+    value = str(uuid7())
+    parts = value.split("-")
     assert len(parts) == 5, "UUID should have 5 parts"
     variant_char = parts[3][0].lower()
     assert variant_char in ["8", "9", "a", "b"], (
@@ -47,30 +57,87 @@ def test_uuid_timestamp_monotonicity():
     """Test that UUIDs generated sequentially have increasing timestamps."""
     uuids = [uuid7() for _ in range(10)]
 
-    # Extract timestamp parts (first two segments)
-    timestamps = []
-    for uuid in uuids:
-        parts = uuid.split("-")
-        # Combine first two parts to get timestamp
-        timestamp_hex = parts[0] + parts[1]
-        timestamps.append(int(timestamp_hex, 16))
+    timestamps = [_timestamp_ms(value) for value in uuids]
 
-    # Check that timestamps are non-decreasing (allowing for small variations)
     for i in range(1, len(timestamps)):
-        assert timestamps[i] >= timestamps[i - 1] - 1, (
+        assert timestamps[i] >= timestamps[i - 1], (
             f"Timestamps should be non-decreasing: {timestamps[i - 1]} -> {timestamps[i]}"
         )
 
 
 def test_uuid_type():
-    """Test that uuid7 returns a string."""
-    uuid = uuid7()
-    assert isinstance(uuid, str), f"UUID should be a string, got {type(uuid)}"
+    """Test that uuid7 returns a UUID object."""
+    value = uuid7()
+    assert isinstance(value, uuid.UUID), f"UUID should be uuid.UUID, got {type(value)}"
+    assert value.version == 7
+    assert value.variant == uuid.RFC_4122
+    assert value == uuid.UUID(str(value))
+
+
+def test_uuid7_result_is_immutable():
+    """Test that fast construction preserves UUID immutability."""
+    value = uuid7()
+    try:
+        value.int = 0
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("UUID objects should be immutable")
+
+
+def test_uuid7_str_fast_path():
+    """Test that uuid7_str returns a canonical UUIDv7 string."""
+    value = uuid7_str()
+    assert isinstance(value, str)
+    assert UUID7_PATTERN.match(value)
+    parsed = uuid.UUID(value)
+    assert parsed.version == 7
+    assert parsed.variant == uuid.RFC_4122
+
+
+def test_uuid7_bytes_fast_path():
+    """Test that uuid7_bytes returns UUIDv7 bytes."""
+    value = uuid7_bytes()
+    assert isinstance(value, bytes)
+    assert len(value) == 16
+    parsed = uuid.UUID(bytes=value)
+    assert parsed.version == 7
+    assert parsed.variant == uuid.RFC_4122
+
+
+def test_uuid_time_matches_uuidv7_timestamp_bits():
+    """Test Python 3.14-compatible UUIDv7 time semantics."""
+    before = int(time.time() * 1000)
+    value = uuid7()
+    after = int(time.time() * 1000)
+
+    assert value.time == _timestamp_ms(value)
+    assert before <= value.time <= after + 1
+
+
+def test_same_millisecond_values_are_monotonic():
+    """Test monotonic ordering for UUIDs generated within the same millisecond."""
+    _reset_state_for_tests()
+    timestamp_ms = int(time.time() * 1000)
+    uuids = [uuid.UUID(bytes=_generate_uuid7_bytes_for_tests(timestamp_ms)) for _ in range(1000)]
+    assert uuids == sorted(uuids)
+    assert len(uuids) == len(set(uuids))
+
+
+def test_clock_rollback_does_not_decrease_uuid_values():
+    """Test generator state when the observed clock moves backwards."""
+    _reset_state_for_tests()
+    timestamp_ms = int(time.time() * 1000)
+    first = uuid.UUID(bytes=_generate_uuid7_bytes_for_tests(timestamp_ms))
+    second = uuid.UUID(bytes=_generate_uuid7_bytes_for_tests(timestamp_ms - 1000))
+
+    assert second.int > first.int
+    assert _timestamp_ms(second) == timestamp_ms
 
 
 def test_multiple_calls():
     """Test that the function can be called multiple times without errors."""
     for _ in range(100):
-        uuid = uuid7()
-        assert uuid is not None
-        assert len(uuid) == 36
+        value = uuid7()
+        assert value is not None
+        assert len(str(value)) == 36

--- a/uuidv7/__init__.py
+++ b/uuidv7/__init__.py
@@ -1,10 +1,64 @@
-"""UUID v7 generation package - fastuuid7."""
+"""Fast UUID v7 generation compatible with :func:`uuid.uuid7`."""
 
-from uuidv7.uuidv7_impl.uuid7_gen import generate_uuid7
+from __future__ import annotations
 
-# Export uuid7 function following Python standard library naming convention
-# This matches uuid.uuid7() from Python 3.14+
-uuid7 = generate_uuid7
+import uuid as _uuid
 
-__version__ = "0.1.0"
-__all__ = ["uuid7", "__version__"]
+from uuidv7.uuidv7_impl.uuid7_gen import (
+    generate_uuid7 as _generate_uuid7_str,
+)
+from uuidv7.uuidv7_impl.uuid7_gen import (
+    generate_uuid7_bytes as _generate_uuid7_bytes,
+)
+from uuidv7.uuidv7_impl.uuid7_gen import (
+    generate_uuid7_int as _generate_uuid7_int,
+)
+
+
+class _UUID7(_uuid.UUID):
+    """UUID subclass that exposes Python 3.14-compatible UUIDv7 ``time``."""
+
+    @property
+    def time(self) -> int:
+        if self.version == 7:
+            return self.int >> 80
+        return super().time
+
+    def __repr__(self) -> str:
+        return f"UUID('{self}')"
+
+
+_UUID_NEW = _uuid.UUID.__new__
+_OBJECT_SETATTR = object.__setattr__
+_SAFE_UUID_UNKNOWN = _uuid.SafeUUID.unknown
+
+
+def _uuid7_from_int(value: int) -> _uuid.UUID:
+    uuid_obj = _UUID_NEW(_UUID7)
+    _OBJECT_SETATTR(uuid_obj, "int", value)
+    _OBJECT_SETATTR(uuid_obj, "is_safe", _SAFE_UUID_UNKNOWN)
+    return uuid_obj
+
+
+def uuid7() -> _uuid.UUID:
+    """Generate a UUID version 7 value.
+
+    The return value is compatible with Python's ``uuid.uuid7()`` API. On
+    Python versions older than 3.14, a private ``uuid.UUID`` subclass is used
+    so that ``u.time`` returns the UUIDv7 Unix timestamp in milliseconds.
+    """
+    return _uuid7_from_int(_generate_uuid7_int())
+
+
+def uuid7_str() -> str:
+    """Generate a UUID version 7 value as a canonical string."""
+    return _generate_uuid7_str()
+
+
+def uuid7_bytes() -> bytes:
+    """Generate a UUID version 7 value as 16 big-endian bytes."""
+    return _generate_uuid7_bytes()
+
+
+__version__ = "0.2.0"
+__all__ = ["uuid7", "uuid7_bytes", "uuid7_str", "__version__"]

--- a/uuidv7/uuidv7/__init__.py
+++ b/uuidv7/uuidv7/__init__.py
@@ -2,10 +2,8 @@
 
 # This module is kept for backward compatibility
 # Use 'from uuidv7 import uuid7' instead
+from uuidv7 import uuid7, uuid7_bytes, uuid7_str
 from uuidv7.uuidv7_impl.uuid7_gen import generate_uuid7
 
-# Export both names for compatibility
-uuid7 = generate_uuid7
-
-__version__ = "0.1.0"
-__all__ = ["uuid7", "generate_uuid7"]
+__version__ = "0.2.0"
+__all__ = ["uuid7", "uuid7_bytes", "uuid7_str", "generate_uuid7"]

--- a/uuidv7/uuidv7_impl/include/uuid7_gen.h
+++ b/uuidv7/uuidv7_impl/include/uuid7_gen.h
@@ -1,6 +1,10 @@
 #ifndef UUID7_GEN_H
 #define UUID7_GEN_H
 
-void generate_uuid7(char *uuid);
+#include <stdint.h>
+
+void generate_uuid7_bytes(unsigned char uuid[16]);
+void generate_uuid7_bytes_for_timestamp(unsigned char uuid[16], uint64_t unix_ts_ms);
+void reset_uuid7_state(void);
 
 #endif

--- a/uuidv7/uuidv7_impl/src/uuid7_gen.c
+++ b/uuidv7/uuidv7_impl/src/uuid7_gen.c
@@ -1,37 +1,151 @@
 #include "uuid7_gen.h"
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-#include <stdint.h>
 
-// Function to generate a UUIDv7
-void generate_uuid7(char *uuid) {
-    static int seeded = 0;
-    if (!seeded) {
-        srand(time(NULL));
-        seeded = 1;
+#include <stddef.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <time.h>
+#include <unistd.h>
+#if !defined(CLOCK_REALTIME)
+#include <sys/time.h>
+#endif
+#endif
+
+#define UUID7_COUNTER_MASK ((UINT64_C(1) << 42) - UINT64_C(1))
+#define UUID7_COUNTER_LOW_MASK ((UINT64_C(1) << 30) - UINT64_C(1))
+
+static uint64_t last_ms = 0;
+static uint64_t counter = 0;
+static uint64_t rng_state = 0;
+static int initialized = 0;
+
+static uint64_t current_time_ms(void) {
+#ifdef _WIN32
+    FILETIME ft;
+    ULARGE_INTEGER uli;
+    typedef VOID(WINAPI *GetSystemTimePreciseAsFileTimeFn)(LPFILETIME);
+    static int resolved_precise_time = 0;
+    static GetSystemTimePreciseAsFileTimeFn get_system_time_precise_as_file_time = NULL;
+
+    if (!resolved_precise_time) {
+        HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
+        if (kernel32 != NULL) {
+            get_system_time_precise_as_file_time =
+                (GetSystemTimePreciseAsFileTimeFn)GetProcAddress(
+                    kernel32, "GetSystemTimePreciseAsFileTime"
+                );
+        }
+        resolved_precise_time = 1;
     }
-    
+
+    if (get_system_time_precise_as_file_time != NULL) {
+        get_system_time_precise_as_file_time(&ft);
+    } else {
+        GetSystemTimeAsFileTime(&ft);
+    }
+
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+    return (uli.QuadPart - UINT64_C(116444736000000000)) / UINT64_C(10000);
+#else
+#ifdef CLOCK_REALTIME
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
+    return (uint64_t)ts.tv_sec * UINT64_C(1000) + (uint64_t)(ts.tv_nsec / 1000000);
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint64_t)tv.tv_sec * UINT64_C(1000) + (uint64_t)(tv.tv_usec / 1000);
+#endif
+#endif
+}
 
-    // Get current time in milliseconds
-    uint64_t time_ms = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+static uint64_t seed_value(void) {
+    uint64_t seed = current_time_ms();
+    seed ^= (uint64_t)(uintptr_t)&seed;
+    seed ^= (uint64_t)(uintptr_t)&last_ms << 17;
+#ifdef _WIN32
+    seed ^= (uint64_t)GetCurrentProcessId() << 32;
+#else
+    seed ^= (uint64_t)getpid() << 32;
+#endif
+    return seed ? seed : UINT64_C(0x9e3779b97f4a7c15);
+}
 
-    // Random part for the UUID
-    uint16_t rand_a = rand() & 0xFFFF;
-    uint16_t rand_b = rand() & 0xFFFF;
-    uint16_t rand_c = rand() & 0xFFFF;
-    uint16_t rand_d = rand() & 0xFFFF;
-    uint16_t rand_e = rand() & 0xFFFF;
+static uint64_t random_u64(void) {
+    uint64_t x;
 
-    // Compile UUIDv7 string (format: 8-4-4-4-12 hex digits)
-    snprintf(uuid, 37, "%08llx-%04llx-%04x-%04x-%04x%04x%04x",
-            (unsigned long long)(time_ms >> 28), // higher timestamp part
-            (unsigned long long)((time_ms >> 12) & 0xFFFF), // lower timestamp part
-            (rand_a & 0x0FFF) | 0x7000, // adjust version field to v7
-            (rand_b & 0x3FFF) | 0x8000, // adjust variant
-            rand_c,
-            rand_d,
-            rand_e);
+    if (rng_state == 0) {
+        rng_state = seed_value();
+    }
+
+    x = rng_state;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    rng_state = x;
+    return x * UINT64_C(2685821657736338717);
+}
+
+static uint64_t next_counter_start(void) {
+    return random_u64() & UUID7_COUNTER_MASK;
+}
+
+void reset_uuid7_state(void) {
+    last_ms = 0;
+    counter = 0;
+    rng_state = 0;
+    initialized = 0;
+}
+
+void generate_uuid7_bytes_for_timestamp(unsigned char uuid[16], uint64_t unix_ts_ms) {
+    uint64_t timestamp_ms = unix_ts_ms;
+    uint64_t rand_b;
+    uint32_t random_tail;
+    uint16_t rand_a;
+
+    if (!initialized) {
+        rng_state = seed_value();
+        counter = next_counter_start();
+        initialized = 1;
+    }
+
+    if (timestamp_ms > last_ms) {
+        last_ms = timestamp_ms;
+        counter = next_counter_start();
+    } else {
+        timestamp_ms = last_ms;
+        counter = (counter + 1) & UUID7_COUNTER_MASK;
+        if (counter == 0) {
+            last_ms += 1;
+            timestamp_ms = last_ms;
+            counter = next_counter_start();
+        }
+    }
+
+    random_tail = (uint32_t)random_u64();
+    rand_a = (uint16_t)((counter >> 30) & UINT64_C(0x0fff));
+    rand_b = ((counter & UUID7_COUNTER_LOW_MASK) << 32) | (uint64_t)random_tail;
+
+    uuid[0] = (unsigned char)(timestamp_ms >> 40);
+    uuid[1] = (unsigned char)(timestamp_ms >> 32);
+    uuid[2] = (unsigned char)(timestamp_ms >> 24);
+    uuid[3] = (unsigned char)(timestamp_ms >> 16);
+    uuid[4] = (unsigned char)(timestamp_ms >> 8);
+    uuid[5] = (unsigned char)timestamp_ms;
+    uuid[6] = (unsigned char)(0x70 | (rand_a >> 8));
+    uuid[7] = (unsigned char)rand_a;
+    uuid[8] = (unsigned char)(0x80 | ((rand_b >> 56) & 0x3f));
+    uuid[9] = (unsigned char)(rand_b >> 48);
+    uuid[10] = (unsigned char)(rand_b >> 40);
+    uuid[11] = (unsigned char)(rand_b >> 32);
+    uuid[12] = (unsigned char)(rand_b >> 24);
+    uuid[13] = (unsigned char)(rand_b >> 16);
+    uuid[14] = (unsigned char)(rand_b >> 8);
+    uuid[15] = (unsigned char)rand_b;
+}
+
+void generate_uuid7_bytes(unsigned char uuid[16]) {
+    generate_uuid7_bytes_for_timestamp(uuid, current_time_ms());
 }

--- a/uuidv7/uuidv7_impl/uuid7_gen.c
+++ b/uuidv7/uuidv7_impl/uuid7_gen.c
@@ -2,19 +2,150 @@
 #include <Python.h>
 #include "uuid7_gen.h"
 
-// Import the C implementation function
-extern void generate_uuid7(char *uuid);
+#if defined(Py_LIMITED_API)
+static uint64_t read_u64_be(const unsigned char bytes[8]) {
+    return ((uint64_t)bytes[0] << 56) |
+           ((uint64_t)bytes[1] << 48) |
+           ((uint64_t)bytes[2] << 40) |
+           ((uint64_t)bytes[3] << 32) |
+           ((uint64_t)bytes[4] << 24) |
+           ((uint64_t)bytes[5] << 16) |
+           ((uint64_t)bytes[6] << 8) |
+           (uint64_t)bytes[7];
+}
+#endif
+
+static PyObject *uuid_bytes_to_int(const unsigned char uuid[16]) {
+#if !defined(Py_LIMITED_API)
+    return _PyLong_FromByteArray(uuid, 16, 0, 0);
+#else
+    PyObject *high = NULL;
+    PyObject *low = NULL;
+    PyObject *shift = NULL;
+    PyObject *shifted = NULL;
+    PyObject *result = NULL;
+
+    high = PyLong_FromUnsignedLongLong(read_u64_be(uuid));
+    if (high == NULL) {
+        goto done;
+    }
+
+    low = PyLong_FromUnsignedLongLong(read_u64_be(uuid + 8));
+    if (low == NULL) {
+        goto done;
+    }
+
+    shift = PyLong_FromLong(64);
+    if (shift == NULL) {
+        goto done;
+    }
+
+    shifted = PyNumber_Lshift(high, shift);
+    if (shifted == NULL) {
+        goto done;
+    }
+
+    result = PyNumber_Or(shifted, low);
+
+done:
+    Py_XDECREF(high);
+    Py_XDECREF(low);
+    Py_XDECREF(shift);
+    Py_XDECREF(shifted);
+    return result;
+#endif
+}
+
+static void format_uuid7(const unsigned char uuid[16], char text[37]) {
+    static const char hex[] = "0123456789abcdef";
+    int source = 0;
+    int target = 0;
+
+    while (source < 16) {
+        if (target == 8 || target == 13 || target == 18 || target == 23) {
+            text[target++] = '-';
+        }
+        text[target++] = hex[uuid[source] >> 4];
+        text[target++] = hex[uuid[source] & 0x0f];
+        source++;
+    }
+    text[36] = '\0';
+}
 
 static PyObject *py_generate_uuid7(PyObject *self, PyObject *args) {
-    char uuid[37];
-    
-    generate_uuid7(uuid);
-    
-    return PyUnicode_FromString(uuid);
+    unsigned char uuid[16];
+    char text[37];
+
+    (void)self;
+    (void)args;
+
+    generate_uuid7_bytes(uuid);
+    format_uuid7(uuid, text);
+
+    return PyUnicode_FromStringAndSize(text, 36);
+}
+
+static PyObject *py_generate_uuid7_bytes(PyObject *self, PyObject *args) {
+    unsigned char uuid[16];
+
+    (void)self;
+    (void)args;
+
+    generate_uuid7_bytes(uuid);
+
+    return PyBytes_FromStringAndSize((const char *)uuid, 16);
+}
+
+static PyObject *py_generate_uuid7_int(PyObject *self, PyObject *args) {
+    unsigned char uuid[16];
+
+    (void)self;
+    (void)args;
+
+    generate_uuid7_bytes(uuid);
+
+    return uuid_bytes_to_int(uuid);
+}
+
+static PyObject *py_generate_uuid7_bytes_for_tests(PyObject *self, PyObject *args) {
+    unsigned char uuid[16];
+    unsigned long long timestamp_ms;
+
+    (void)self;
+
+    if (!PyArg_ParseTuple(args, "K", &timestamp_ms)) {
+        return NULL;
+    }
+
+    generate_uuid7_bytes_for_timestamp(uuid, (uint64_t)timestamp_ms);
+
+    return PyBytes_FromStringAndSize((const char *)uuid, 16);
+}
+
+static PyObject *py_reset_state_for_tests(PyObject *self, PyObject *args) {
+    (void)self;
+    (void)args;
+
+    reset_uuid7_state();
+    Py_RETURN_NONE;
 }
 
 static PyMethodDef uuid7_gen_methods[] = {
-    {"generate_uuid7", py_generate_uuid7, METH_NOARGS, "Generate a UUID v7"},
+    {"generate_uuid7", py_generate_uuid7, METH_NOARGS, "Generate a UUID v7 string"},
+    {"generate_uuid7_bytes", py_generate_uuid7_bytes, METH_NOARGS, "Generate UUID v7 bytes"},
+    {"generate_uuid7_int", py_generate_uuid7_int, METH_NOARGS, "Generate a UUID v7 integer"},
+    {
+        "_generate_uuid7_bytes_for_tests",
+        py_generate_uuid7_bytes_for_tests,
+        METH_VARARGS,
+        "Generate UUID v7 bytes for a specific timestamp"
+    },
+    {
+        "_reset_state_for_tests",
+        py_reset_state_for_tests,
+        METH_NOARGS,
+        "Reset UUID v7 generator state"
+    },
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
## Summary
- updates the pre-1.0 API so `uuidv7.uuid7()` returns a `uuid.UUID`-compatible object
- adds fast `uuid7_str()` and `uuid7_bytes()` paths
- adds Windows-compatible time source handling and cibuildwheel-based wheel builds for Linux, macOS, and Windows
- records benchmark results for the 0.2.0 candidate, published `fastuuid7==0.1.0`, and competitor packages

## Validation
- `pytest`: 13 passed
- `ruff check`: passed
- `ruff format --check`: passed
- source distribution and Linux wheel build: passed
- installed wheel smoke test: passed
- `twine check` for wheel and sdist: passed

## Release note
Do not tag or publish until CI, wheel builds, and benchmark workflow results are green and reviewed.